### PR TITLE
Cargo:toml: bump cookie_store/cookie deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 bytes = "1.0.1"
-cookie = "0.16.0"
-cookie_store = "0.16.0"
+cookie = "0.16.1"
+cookie_store = "0.18.0"
 reqwest = { version = "0.11.3", default-features = false, features = ["cookies"] }
 url = "2.2.2"
 


### PR DESCRIPTION
CookieStore added a new save_incl_expired_and_nonpersistent{,_json} API starting with v0.18.0 and if one wants to use the new API to save/load cookies which are passed to reqwest_cookie_store, the dep versions needs bumping.

While at it also bump cookies to the latest minor version.

Signed-off-by: Adrian Ratiu <adi@adirat.com>