### PR TITLE
Bump cookie_store

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ serde = ["dep:serde" , "dep:serde_derive"]
 
 [dependencies]
 bytes = "1.0.1"
-cookie_store = "^0.21"
+cookie_store = "^0.22"
 reqwest = { version = "^0.12", default-features = false, features = ["cookies"] }
 url = "2.2.2"
 serde = {version = "1.0.147",  optional = true}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 //!       cookie_store::serde::json::load(file).unwrap()
 //!     }
 //!     else {
-//!       reqwest_cookie_store::CookieStore::new(None)
+//!       reqwest_cookie_store::CookieStore::new()
 //!     }
 //! };
 //! let cookie_store = reqwest_cookie_store::CookieStoreMutex::new(cookie_store);


### PR DESCRIPTION
Trying to bump dependencies in the [lychee project](https://github.com/lycheeverse/lychee) we ran into the issue of `reqwest_cookie_store` using an outdated version of `cookie_store`. You can take a look at the [CI failure](https://github.com/lycheeverse/lychee/actions/runs/16961429219/job/48074967805) if you're interested. The compiler error message is:

```
note: two different versions of crate `cookie_store` are being used; two types coming from two different versions of the same crate are different types even if they look the same
```

Bumping the dependency as is done in this PR resolves the problem.